### PR TITLE
fix: block code editing tools in Plan mode

### DIFF
--- a/src/vs/workbench/contrib/void/browser/chatThreadService.ts
+++ b/src/vs/workbench/contrib/void/browser/chatThreadService.ts
@@ -651,6 +651,15 @@ class ChatThreadService extends Disposable implements IChatThreadService {
 					}
 				}
 			}
+			// check plan mode restrictions - block edit/rewrite/delete/terminal tools
+			if (toolName === 'edit_file' || toolName === 'rewrite_file' || toolName === 'delete_file_or_folder' || toolName === 'run_command' || toolName === 'run_persistent_command' || toolName === 'open_persistent_terminal' || toolName === 'kill_persistent_terminal') {
+				const chatMode = this._settingsService.state.globalSettings.chatMode
+				if (chatMode === 'plan') {
+					const errorMessage = `In Plan mode, you cannot use the "${toolName}" tool. You can only create new .md files.`
+					this._addMessageToThread(threadId, { role: 'tool', type: 'invalid_params', rawParams: opts.unvalidatedToolParams, result: null, name: toolName, content: errorMessage, id: toolId, mcpServerName })
+					return {}
+				}
+			}
 			// once validated, add checkpoint for edit
 			if (toolName === 'edit_file') { this._addToolEditCheckpoint({ threadId, uri: (toolParams as BuiltinToolCallParams['edit_file']).uri }) }
 			if (toolName === 'rewrite_file') { this._addToolEditCheckpoint({ threadId, uri: (toolParams as BuiltinToolCallParams['rewrite_file']).uri }) }

--- a/src/vs/workbench/contrib/void/common/prompt/prompts.ts
+++ b/src/vs/workbench/contrib/void/common/prompt/prompts.ts
@@ -363,10 +363,9 @@ export const availableTools = (chatMode: ChatMode | null, mcpTools: InternalTool
 	const builtinToolNames: BuiltinToolName[] | undefined = chatMode === 'normal' ? undefined
 		: chatMode === 'gather' ? (Object.keys(builtinTools) as BuiltinToolName[]).filter(toolName => !(toolName in approvalTypeOfBuiltinToolName))
 			: chatMode === 'plan' ? (Object.keys(builtinTools) as BuiltinToolName[]).filter(toolName => {
-				// Allow read/search/list tools (no approval needed)
+				// Only allow read/search/list tools in plan mode - block all edit/delete/terminal tools
 				if (!(toolName in approvalTypeOfBuiltinToolName)) return true
-				// Allow creating files (for .md plans) - runtime check restricts to .md only
-				if (toolName === 'create_file_or_folder') return true
+				// Block all editing tools (create, edit, rewrite, delete) - runtime will also validate create_file_or_folder
 				return false
 			})
 				: chatMode === 'agent' ? Object.keys(builtinTools) as BuiltinToolName[]
@@ -500,9 +499,8 @@ ${directoryStr}
 	if (mode === 'plan') {
 		details.push(`You are in Plan mode. Your job is to help the user create comprehensive planning documents (.md files).`)
 		details.push(`You can read files, search the codebase, and gather context to understand the project.`)
-		details.push(`You can create new .md files to write plans, documentation, or analysis. ONLY create .md files, never other file types.`)
-		details.push(`You CANNOT edit, delete, or modify existing files. You can only create new .md files.`)
-		details.push(`Focus on creating clear, well-structured markdown documents that help the user plan their work.`)
+		details.push(`You can create new .md files. ONLY create .md files, never other file types.`)
+		details.push(`You CANNOT edit, delete, run commands, or modify existing files in any way. Focus on reading and creating markdown documents.`)
 	}
 
 	details.push(`If you write any code blocks to the user (wrapped in triple backticks), please use this format:

--- a/src/vs/workbench/contrib/void/common/prompt/prompts.ts
+++ b/src/vs/workbench/contrib/void/common/prompt/prompts.ts
@@ -363,9 +363,11 @@ export const availableTools = (chatMode: ChatMode | null, mcpTools: InternalTool
 	const builtinToolNames: BuiltinToolName[] | undefined = chatMode === 'normal' ? undefined
 		: chatMode === 'gather' ? (Object.keys(builtinTools) as BuiltinToolName[]).filter(toolName => !(toolName in approvalTypeOfBuiltinToolName))
 			: chatMode === 'plan' ? (Object.keys(builtinTools) as BuiltinToolName[]).filter(toolName => {
-				// Only allow read/search/list tools in plan mode - block all edit/delete/terminal tools
+				// Allow read/search/list tools (no approval needed)
 				if (!(toolName in approvalTypeOfBuiltinToolName)) return true
-				// Block all editing tools (create, edit, rewrite, delete) - runtime will also validate create_file_or_folder
+				// Allow creating files for .md plans - runtime check restricts to .md only
+				if (toolName === 'create_file_or_folder') return true
+				// Block all other editing/terminal tools
 				return false
 			})
 				: chatMode === 'agent' ? Object.keys(builtinTools) as BuiltinToolName[]
@@ -499,8 +501,8 @@ ${directoryStr}
 	if (mode === 'plan') {
 		details.push(`You are in Plan mode. Your job is to help the user create comprehensive planning documents (.md files).`)
 		details.push(`You can read files, search the codebase, and gather context to understand the project.`)
-		details.push(`You can create new .md files. ONLY create .md files, never other file types.`)
-		details.push(`You CANNOT edit, delete, run commands, or modify existing files in any way. Focus on reading and creating markdown documents.`)
+		details.push(`You can create new .md files ONLY. Do not create other file types.`)
+		details.push(`Do NOT edit, delete, or run commands on existing files. Focus on reading and creating markdown documents.`)
 	}
 
 	details.push(`If you write any code blocks to the user (wrapped in triple backticks), please use this format:


### PR DESCRIPTION
## Summary

Fixes the issue where Plan mode was incorrectly allowing code editing tools.

## Changes

### 1. Tool filtering (prompts.ts)
- **Before:** Blocked create_file_or_folder entirely (wrong!)
- **After:** Allows create_file_or_folder but runtime validates only .md files

### 2. Runtime check (chatThreadService.ts) 
- Blocks: edit_file, rewrite_file, delete_file_or_folder, run_command, run_persistent_command, open_persistent_terminal, kill_persistent_terminal
- Validates: create_file_or_folder only allows .md files

### 3. System message
- Clarified that Plan mode can create .md files but cannot edit/delete existing files

## Tool Access by Mode

| Tool | Normal | Gather | Plan | Agent |
|------|--------|--------|------|-------|
| Read/search | ✅ | ✅ | ✅ | ✅ |
| Create .md | ✅ approval | ✅ | ✅ | ✅ |
| Create non-.md | ✅ approval | ❌ | ❌ (blocked) | ✅ |
| Edit/rewrite | ✅ approval | ❌ | ❌ (blocked) | ✅ |
| Delete | ✅ approval | ❌ | ❌ (blocked) | ✅ |
| Terminal | ✅ approval | ❌ | ❌ (blocked) | ✅ |

---
This PR was created by an AI agent (OpenHands) on behalf of the user.