### PR TITLE
fix: add error handling for Gofile.io upload failures

### DIFF
--- a/.github/workflows/ci-build-macos.yml
+++ b/.github/workflows/ci-build-macos.yml
@@ -24,10 +24,10 @@ env:
   ELECTRON_BUILDER_CACHE: ${{ github.workspace }}/.cache/electron-builder
 
 jobs:
-  # ─────────────────────────────────────────────────────────────────────────────
+  # ────────────────────────────────────────────────────────────────[...]
   # Fast PR check — compiles only. Full DMG/ZIP/REH builds only run on dispatch,
   # since macOS runners are the most expensive minute-for-minute on GitHub Actions.
-  # ─────────────────────────────────────────────────────────────────────────────
+  # ────────────────────────────────────────────────────────────────[...]
   pr-check:
     name: PR Compile Check
     if: github.event_name == 'pull_request'
@@ -61,9 +61,9 @@ jobs:
         env:
           NODE_OPTIONS: '--max-old-space-size=8192'
 
-  # ─────────────────────────────────────────────────────────────────────────────
+  # ────────────────────────────────────────────────────────────────[...]
   # Resolve version — only needed for the real release builds
-  # ─────────────────────────────────────────────────────────────────────────────
+  # ────────────────────────────────────────────────────────────────[...]
   resolve-version:
     name: Resolve Version
     if: github.event_name == 'workflow_dispatch'
@@ -90,9 +90,9 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Resolved version: $VERSION"
 
-  # ─────────────────────────────────────────────────────────────────────────────
+  # ────────────────────────────────────────────────────────────────[...]
   # Build: macOS x64 (Intel)
-  # ─────────────────────────────────────────────────────────────────────────────
+  # ────────────────────────────────────────────────────────────────[...]
   build-macos-x64:
     name: Build macOS x64 (Intel)
     needs: resolve-version
@@ -109,7 +109,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      # ── Toolchain ─────────────────────────────────────────────────────────────
+      # ── Toolchain ──────────────────────────────────────────────────────────[...]
       - name: Setup Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v4
         with:
@@ -126,7 +126,7 @@ jobs:
         with:
           targets: x86_64-apple-darwin
 
-      # ── Caches ────────────────────────────────────────────────────────────────
+      # ── Caches ───────────────────────────────────────────────────────────[...]
       - name: Cache Rust artifacts
         uses: actions/cache@v4
         with:
@@ -300,7 +300,7 @@ jobs:
           tar -czf "dist/loophole-reh-web-darwin-x64-$VERSION.tar.gz" \
             -C "$(dirname "$REH_WEB_PATH")" "$(basename "$REH_WEB_PATH")"
 
-      # ── 5. CLI tarball ─────────────────────────────────────────────────────────
+      # ── 5. CLI tarball ───────────────────────────────────────────────────────[...]
       - name: Stage — CLI tarball
         run: |
           cli_bin="cli/target/x86_64-apple-darwin/release/loophole"
@@ -313,7 +313,7 @@ jobs:
             echo "::warning::CLI binary not found — skipping"
           fi
 
-      # ── Summary & upload ───────────────────────────────────────────────────────
+      # ── Summary & upload ────────────────────────────────────────────────────────[...]
       - name: List built artifacts
         run: |
           echo "=== dist/ artifacts ==="
@@ -369,7 +369,11 @@ jobs:
           echo "======================================"
 
           # Get best available server
-          SERVER=$(curl -s https://api.gofile.io/servers | python3 -c "import sys,json; data=json.load(sys.stdin); print(data['data']['servers'][0]['name'])")
+          SERVER=$(curl -s https://api.gofile.io/servers | python3 -c "import sys,json; data=json.load(sys.stdin); print(data['data']['servers'][0]['name'])" 2>/dev/null)
+          if [ -z "$SERVER" ]; then
+            echo "::warning::Failed to get Gofile.io server — skipping upload"
+            exit 0
+          fi
           echo "Using server: $SERVER"
 
           for FILE in dist/*.{dmg,zip,tar.gz}; do
@@ -378,15 +382,25 @@ jobs:
               echo ""
               echo "Uploading: $FILENAME"
               RESPONSE=$(curl -s -F "file=@$FILE" "https://$SERVER.gofile.io/uploadFile")
-              echo "Response: $RESPONSE"
-              LINK=$(echo $RESPONSE | python3 -c "import sys,json; data=json.load(sys.stdin); print(data['data']['downloadPage'])")
-              echo " $FILENAME → $LINK"
+              
+              # Validate response is valid JSON before parsing
+              if ! echo "$RESPONSE" | python3 -c "import sys,json; json.load(sys.stdin)" 2>/dev/null; then
+                echo "::warning::Invalid response from Gofile.io for $FILENAME: $RESPONSE"
+                continue
+              fi
+              
+              LINK=$(echo "$RESPONSE" | python3 -c "import sys,json; data=json.load(sys.stdin); print(data.get('data', {}).get('downloadPage', 'N/A'))" 2>/dev/null)
+              if [ -n "$LINK" ] && [ "$LINK" != "N/A" ]; then
+                echo " $FILENAME → $LINK"
+              else
+                echo "::warning::Could not extract download link for $FILENAME"
+              fi
             fi
           done
 
-  # ─────────────────────────────────────────────────────────────────────────────
+  # ─────────────────────────────────────────────────────────────────[...]
   # Build: macOS ARM64 (Apple Silicon)
-  # ─────────────────────────────────────────────────────────────────────────────
+  # ─────────────────────────────────────────────────────────────────[...]
   build-macos-arm64:
     name: Build macOS ARM64 (Apple Silicon)
     needs: resolve-version
@@ -403,7 +417,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      # ── Toolchain ─────────────────────────────────────────────────────────────
+      # ── Toolchain ──────────────────────────────────────────────────────────[...]
       - name: Setup Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v4
         with:
@@ -420,7 +434,7 @@ jobs:
         with:
           targets: aarch64-apple-darwin
 
-      # ── Caches ────────────────────────────────────────────────────────────────
+      # ── Caches ───────────────────────────────────────────────────────────[...]
       - name: Cache Rust artifacts
         uses: actions/cache@v4
         with:
@@ -589,7 +603,7 @@ jobs:
           tar -czf "dist/loophole-reh-web-darwin-arm64-$VERSION.tar.gz" \
             -C "$(dirname "$REH_WEB_PATH")" "$(basename "$REH_WEB_PATH")"
 
-      # ── 5. CLI tarball ─────────────────────────────────────────────────────────
+      # ── 5. CLI tarball ───────────────────────────────────────────────────────[...]
       - name: Stage — CLI tarball
         run: |
           cli_bin="cli/target/aarch64-apple-darwin/release/loophole"
@@ -602,7 +616,7 @@ jobs:
             echo "::warning::CLI binary not found — skipping"
           fi
 
-      # ── Summary & upload ───────────────────────────────────────────────────────
+      # ── Summary & upload ────────────────────────────────────────────────────────[...]
       - name: List built artifacts
         run: |
           echo "=== dist/ artifacts ==="
@@ -658,7 +672,11 @@ jobs:
           echo "======================================"
 
           # Get best available server
-          SERVER=$(curl -s https://api.gofile.io/servers | python3 -c "import sys,json; data=json.load(sys.stdin); print(data['data']['servers'][0]['name'])")
+          SERVER=$(curl -s https://api.gofile.io/servers | python3 -c "import sys,json; data=json.load(sys.stdin); print(data['data']['servers'][0]['name'])" 2>/dev/null)
+          if [ -z "$SERVER" ]; then
+            echo "::warning::Failed to get Gofile.io server — skipping upload"
+            exit 0
+          fi
           echo "Using server: $SERVER"
 
           for FILE in dist/*.{dmg,zip,tar.gz}; do
@@ -667,8 +685,18 @@ jobs:
               echo ""
               echo "Uploading: $FILENAME"
               RESPONSE=$(curl -s -F "file=@$FILE" "https://$SERVER.gofile.io/uploadFile")
-              echo "Response: $RESPONSE"
-              LINK=$(echo $RESPONSE | python3 -c "import sys,json; data=json.load(sys.stdin); print(data['data']['downloadPage'])")
-              echo " $FILENAME → $LINK"
+              
+              # Validate response is valid JSON before parsing
+              if ! echo "$RESPONSE" | python3 -c "import sys,json; json.load(sys.stdin)" 2>/dev/null; then
+                echo "::warning::Invalid response from Gofile.io for $FILENAME: $RESPONSE"
+                continue
+              fi
+              
+              LINK=$(echo "$RESPONSE" | python3 -c "import sys,json; data=json.load(sys.stdin); print(data.get('data', {}).get('downloadPage', 'N/A'))" 2>/dev/null)
+              if [ -n "$LINK" ] && [ "$LINK" != "N/A" ]; then
+                echo " $FILENAME → $LINK"
+              else
+                echo "::warning::Could not extract download link for $FILENAME"
+              fi
             fi
           done


### PR DESCRIPTION
- Validate server lookup before attempting uploads
- Check if API response is valid JSON before parsing
- Safely extract nested fields using .get() to prevent crashes
- Use graceful degradation with warnings instead of hard failures
- Allow partial uploads if some files fail

Fixes JSON decode error when Gofile.io returns error-createFolderResponse
