### PR TITLE
Modify workflow to regenerate package-lock.json

### DIFF
--- a/.github/workflows/regen-lockfile.yml
+++ b/.github/workflows/regen-lockfile.yml
@@ -1,7 +1,7 @@
 name: Regenerate package-lock.json
 
 on:
-  workflow_dispatch: # run manually from GitHub Actions tab
+  workflow_dispatch:
 
 jobs:
   regen-lockfile:
@@ -18,11 +18,14 @@ jobs:
         with:
           node-version: '22'
 
+      - name: Install system dependencies for native modules
+        run: sudo apt-get install -y libkrb5-dev libgssapi-krb5-2
+
       - name: Delete old lock file
         run: rm -f package-lock.json
 
-      - name: Run npm install (triggers postinstall for all extensions)
-        run: npm install
+      - name: Regenerate package-lock.json
+        run: npm install --package-lock-only
         env:
           npm_config_arch: x64
 


### PR DESCRIPTION
Updated the workflow to regenerate package-lock.json with a focus on installing system dependencies for native modules and using npm install with the --package-lock-only flag.

<!-- Search for existing issues or PRs before submitting. -->
<!-- Ensure your branch is up-to-date with main before opening a PR. -->

**Related Issue**
Closes #

**Description**
A clear description of what this PR changes and why.

**How to Test**
Steps to verify the change works as expected.

**Checklist**
- [ ] Code is up-to-date with main
- [ ] Tested locally
- [ ] No unrelated changes included